### PR TITLE
Select response by @extra field

### DIFF
--- a/include/TDApi/TDLibParameters.cpp
+++ b/include/TDApi/TDLibParameters.cpp
@@ -34,8 +34,11 @@ Php::Value TDLibParameters::setParameter(Php::Parameters &params)
 
 std::string TDLibParameters::toJsonQuery()
 {
+    std::string extra=this->extraParameterValue;
     // ugly, i know. You can PR with a better solution =)
-    std::string parametersJsonQuery = "{\"@type\":\"setTdlibParameters\",\"parameters\":{"
+    std::string parametersJsonQuery = "{\"@type\":\"setTdlibParameters\","
+        "\"@extra\":\""+ extra +"\","
+        "\"parameters\":{"
         "\"use_test_dc\":" + getParameterValue("use_test_dc") + ","
         "\"database_directory\":\"" + getParameterValue("database_directory") + "\","
         "\"files_directory\":\"" + getParameterValue("files_directory") + "\","

--- a/include/TDApi/TDLibParameters.hpp
+++ b/include/TDApi/TDLibParameters.hpp
@@ -1,6 +1,8 @@
 #ifndef TD_API_TDLIBPARAMETERS_H
 #define TD_API_TDLIBPARAMETERS_H
 
+#include <nlohmann/json.hpp>
+
 class TDLibParameters : public Php::Base // namespace: TDApi
 {
     private:
@@ -18,6 +20,8 @@ class TDLibParameters : public Php::Base // namespace: TDApi
 
         // inline void setLocked() { locked == true; }
         // can set parameters if locked == false
+
+    nlohmann::json extraParameterValue="1235847219223";
 };
 
 #endif // TD_API_TDLIBPARAMETERS_H

--- a/include/TDLib/BaseJsonClient.cpp
+++ b/include/TDLib/BaseJsonClient.cpp
@@ -72,7 +72,10 @@ Php::Value BaseJsonClient::receive(Php::Parameters &params)
 
 std::string BaseJsonClient::receive(double timeout)
 {
-    return td_json_client_receive(_client, timeout);
+    const char* result=td_json_client_receive(_client, timeout);
+    if(result == nullptr) {
+        return "";
+    } else return result;
 }
 
 /**

--- a/include/TDLib/JsonClient.cpp
+++ b/include/TDLib/JsonClient.cpp
@@ -8,43 +8,87 @@
 
 #include "../TDApi/TDLibParameters.hpp"
 
-#include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
 // todo: constructor with query like getAuthorizationState by default (possibility to disable)
 
 Php::Value JsonClient::query(Php::Parameters &params)
 {
-    const char *queryParam = params[0];
+    std::string requestString = params[0];
     double timeout = params[1];
-    std::string result = query(queryParam, timeout);
+
+    json request=json::parse(requestString);
+
+    auto extraIt = request.find("@extra");
+    json extra=0;
+    if (extraIt == request.end())
+    {
+        extra=rand();
+        request["@extra"] = extra;
+    } else {
+        extra=extraIt.value();
+    }
+
+    std::string result = query(request.dump().c_str(), timeout, &extra);
     return result;
 }
 
-std::string JsonClient::query(const char *query, double timeout)
+std::string JsonClient::query(const char *query, double timeout, json* extra)
 {
-    // Php::out << "handle before query: " << query << std::endl << std::endl;
-    handleResponses();
-    // checkAuthorizationState();
-    // Php::out << "send query: " << query << std::endl << std::endl;
     BaseJsonClient::send(query);
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    // Php::out << "handle after query: " << query << std::endl << std::endl;
-    handleResponses();
-    // Php::out << "return with response \"" << lastResponse << "\" to query: " << query << std::endl << std::endl;
-    return lastResponse;
+    return waitForResponse(extra, timeout);
     // todo: lastQuery [lastRequest, lastResponse, isSuccess, state] ?
 }
 
 Php::Value JsonClient::getReceivedResponses(Php::Parameters &params)
 {
-    handleResponses();
+    handleResponses(nullptr);
     std::vector<std::string> oldResponses(receivedResponses);
     receivedResponses.clear();
+    receivedResponsesExtras.clear();
     return oldResponses;
 }
 
-void JsonClient::handleResponses()
+
+std::string JsonClient::waitForResponse(json* extra,double timeout) {
+    std::vector<nlohmann::json>::iterator itExtras;
+    std::vector<std::string>::iterator itResponses;
+
+    std::chrono::time_point<std::chrono::high_resolution_clock>
+            currentTime,
+            startedAt = std::chrono::high_resolution_clock::now();
+
+    bool repeat;
+
+    int scannedResponses=0;
+
+    do {
+        handleResponses(extra);
+
+        if(receivedResponsesExtras.size()>scannedResponses) {
+            itExtras=std::next(receivedResponsesExtras.begin(), scannedResponses);
+            itResponses=std::next(receivedResponses.begin(), scannedResponses);
+
+            for(;itExtras!=receivedResponsesExtras.end() && (*itExtras)!=(*extra);itExtras++,itResponses++,scannedResponses++) {
+            }
+            if(itExtras!=receivedResponsesExtras.end()) {
+                return *itResponses;
+            }
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(3));
+
+        currentTime = std::chrono::high_resolution_clock::now();
+        auto time = std::chrono::duration_cast<std::chrono::milliseconds>(currentTime-startedAt);
+        repeat=(time.count()<(int)(timeout*1000.));
+    } while(repeat);
+
+    return "";
+}
+
+
+
+void JsonClient::handleResponses(json* breakOnExtra)
 {
     while(true)
     {
@@ -54,21 +98,35 @@ void JsonClient::handleResponses()
         }
         catch(const std::exception& e)
         {
-            // todo handle exceptions
-            // basic_string::_M_construct null not valid
-            // Php::out << "exception " << e.what() << std::endl << std::endl;
             break;
         }
-        if (lastResponse.empty()) break;
-        auto responseJson = json::parse(lastResponse);
-        // Php::out << "handle response: " << responseJson << std::endl << std::endl;
-        if(responseJson["@type"] == "ok") ;
-        if(responseJson["@type"] == "error") ;
-        if(responseJson["@type"] == "updateAuthorizationState") authorizationState = responseJson["authorization_state"]["@type"];
-        if(responseJson["@type"] == "updateOption") ;
-        if(responseJson["@type"] == "updateConnectionState") ;
-        std::string responseCopy(lastResponse);
-        receivedResponses.push_back(responseCopy);
+
+        if (lastResponse.empty())
+        {
+            break;
+        }
+        else
+        {
+            auto responseJson = json::parse(lastResponse);
+            if(responseJson["@type"] == "ok") ;
+            if(responseJson["@type"] == "error") ;
+            if(responseJson["@type"] == "updateAuthorizationState") authorizationState = responseJson["authorization_state"]["@type"];
+            if(responseJson["@type"] == "updateOption") ;
+            if(responseJson["@type"] == "updateConnectionState") ;
+
+            std::string responseCopy(lastResponse);
+            receivedResponses.push_back(responseCopy);
+
+            int hasExtraInResponse=responseJson.find("@extra")!=responseJson.end();
+            if(hasExtraInResponse) {
+                receivedResponsesExtras.push_back(responseJson["@extra"]);
+            } else {
+                receivedResponsesExtras.push_back(0);
+            }
+            if(breakOnExtra != nullptr && hasExtraInResponse && (*breakOnExtra)==responseJson["@extra"]) {
+                break;
+            }
+        }
     }
 }
 
@@ -78,8 +136,10 @@ Php::Value JsonClient::setTdlibParameters(Php::Parameters &params)
     if(!tdlibParams.instanceOf("TDApi\\TDLibParameters")) throw Php::Exception("First parameter must be instance of TDApi\\TDLibParameters.");
     TDLibParameters *parameters = (TDLibParameters *)tdlibParams.implementation();
     std::string parametersJsonQuery = parameters->toJsonQuery();
-    std::string result = query(parametersJsonQuery.c_str(), defaultTimeout);
-    return result;
+
+    json extra = parameters->extraParameterValue;
+
+    return query(parametersJsonQuery.c_str(), defaultTimeout, &extra);
 }
 
 Php::Value JsonClient::checkDatabaseEncryptionKey(Php::Parameters &params)
@@ -88,8 +148,11 @@ Php::Value JsonClient::checkDatabaseEncryptionKey(Php::Parameters &params)
     json jsonQuery;
     jsonQuery["@type"] = "checkDatabaseEncryptionKey";
     jsonQuery["key"] = key;
-    std::string result = query(jsonQuery.dump().c_str(), defaultTimeout);
-    return result;
+
+    json extra = rand();
+    jsonQuery["@extra"] = extra;
+
+    return query(jsonQuery.dump().c_str(), defaultTimeout, &extra);
 }
 
 Php::Value JsonClient::setDatabaseEncryptionKey(Php::Parameters &params)
@@ -98,17 +161,22 @@ Php::Value JsonClient::setDatabaseEncryptionKey(Php::Parameters &params)
     json jsonQuery;
     jsonQuery["@type"] = "setDatabaseEncryptionKey";
     if(new_encryption_key.length() > 0) jsonQuery["new_encryption_key"] = new_encryption_key;
-    std::string result = query(jsonQuery.dump().c_str(), defaultTimeout);
-    return result;
+
+    json extra = rand();
+    jsonQuery["@extra"] = extra;
+
+    return query(jsonQuery.dump().c_str(), defaultTimeout, &extra);
 }
 
 Php::Value JsonClient::getAuthorizationState(Php::Parameters &params)
 {
-    // double extra = params[0];
     json jsonQuery;
     jsonQuery["@type"] = "getAuthorizationState";
-    std::string result = query(jsonQuery.dump().c_str(), defaultTimeout);
-    return result;
+
+    json extra = rand();
+    jsonQuery["@extra"] = extra;
+
+    return query(jsonQuery.dump().c_str(), defaultTimeout, &extra);
 }
 
 Php::Value JsonClient::setAuthenticationPhoneNumber(Php::Parameters &params)
@@ -117,6 +185,9 @@ Php::Value JsonClient::setAuthenticationPhoneNumber(Php::Parameters &params)
     json jsonQuery;
     jsonQuery["@type"] = "setAuthenticationPhoneNumber";
     jsonQuery["phone_number"] = phone_number;
-    std::string result = query(jsonQuery.dump().c_str(), defaultTimeout);
-    return result;
+
+    json extra = rand();
+    jsonQuery["@extra"] = extra;
+
+    return query(jsonQuery.dump().c_str(), defaultTimeout, &extra);
 }

--- a/include/TDLib/JsonClient.cpp
+++ b/include/TDLib/JsonClient.cpp
@@ -15,7 +15,10 @@ using json = nlohmann::json;
 Php::Value JsonClient::query(Php::Parameters &params)
 {
     std::string requestString = params[0];
-    double timeout = params[1];
+    double timeout=defaultTimeout;
+    if(params.size()>1) {
+        timeout = params[1];
+    }
 
     json request=json::parse(requestString);
 
@@ -190,4 +193,18 @@ Php::Value JsonClient::setAuthenticationPhoneNumber(Php::Parameters &params)
     jsonQuery["@extra"] = extra;
 
     return query(jsonQuery.dump().c_str(), defaultTimeout, &extra);
+}
+
+void JsonClient::setDefaultTimeout(Php::Parameters &params)
+{
+    defaultTimeout = params[0];
+}
+
+Php::Value JsonClient::receive(Php::Parameters &params) {
+    double timeout = defaultTimeout;
+    if(params.size() > 0)
+    {
+        timeout = params[0];
+    }
+    return BaseJsonClient::receive(timeout);
 }

--- a/include/TDLib/JsonClient.hpp
+++ b/include/TDLib/JsonClient.hpp
@@ -30,13 +30,13 @@ class JsonClient : public BaseJsonClient
         Php::Value setAuthenticationPhoneNumber(Php::Parameters &params);
         Php::Value getReceivedResponses(Php::Parameters &params);
 
-        void setDefaultTimeout(Php::Parameters &params) { Php::warning << "implement" << std::flush; };
+        void setDefaultTimeout(Php::Parameters &params);
 
         inline void create() { BaseJsonClient::create(); }
         inline void destroy() { BaseJsonClient::destroy(); }
         inline Php::Value execute(Php::Parameters &params) { BaseJsonClient::execute(params); }
         inline void send(Php::Parameters &params) { BaseJsonClient::send(params); }
-        inline Php::Value receive(Php::Parameters &params) { BaseJsonClient::receive(params); }
+        inline Php::Value receive(Php::Parameters &params);
 
         // internal
 

--- a/include/TDLib/JsonClient.hpp
+++ b/include/TDLib/JsonClient.hpp
@@ -1,6 +1,7 @@
 #ifndef TDLIB_JSONCLIENT_H
 #define TDLIB_JSONCLIENT_H
 
+#include <nlohmann/json.hpp>
 #include "BaseJsonClient.hpp"
 
 class JsonClient : public BaseJsonClient
@@ -9,14 +10,16 @@ class JsonClient : public BaseJsonClient
         // todo: lastResponse json object
         std::string lastResponse;
         std::vector<std::string> receivedResponses;
+        std::vector<nlohmann::json> receivedResponsesExtras;
         std::string authorizationState;
         std::string connectionState;
         double defaultTimeout = 0.5;
 
-        void handleResponses();
+        void handleResponses(nlohmann::json* breakOnExtra);
+        std::string waitForResponse(nlohmann::json* extra,double timeout);
 
     public:
-        std::string query(const char *query, double timeout);
+        std::string query(const char *query, double timeout, nlohmann::json* extra);
 
         // exported
         Php::Value query(Php::Parameters &params);

--- a/tdlib.cpp
+++ b/tdlib.cpp
@@ -47,11 +47,11 @@ PHPCPP_EXPORT void *get_module()
         Php::ByVal("query", Php::Type::String)
     });
     json_client.method<&JsonClient::receive> ("receive", {
-        Php::ByVal("timeout", Php::Type::Numeric)
+        Php::ByVal("timeout", Php::Type::Numeric, false)
     });
     json_client.method<&JsonClient::query> ("query", {
         Php::ByVal("query", Php::Type::String),
-        Php::ByVal("timeout", Php::Type::Numeric)
+        Php::ByVal("timeout", Php::Type::Numeric, false)
     });
     json_client.method<&JsonClient::getReceivedResponses> ("getReceivedResponses");
 
@@ -66,6 +66,9 @@ PHPCPP_EXPORT void *get_module()
     });
     json_client.method<&JsonClient::getAuthorizationState> ("getAuthorizationState", {
         Php::ByVal("extra", Php::Type::Float, false),
+    });
+    json_client.method<&JsonClient::setDefaultTimeout> ("setDefaultTimeout", {
+        Php::ByVal("defaultTimeout", Php::Type::Float),
     });
     json_client.method<&JsonClient::setAuthenticationPhoneNumber> ("setAuthenticationPhoneNumber", {
         Php::ByVal("phone_number", Php::Type::String),


### PR DESCRIPTION
The implementation of method `query` have been returning the last response from tdlib. That is incorrect.

This pull request forces the `query` method to return response with `@extra` field, corresponding to request. The `@extra` is generated automatically if it is not set by user.

This solves the problem of meshed responses which sometimes occurs.