### PR TITLE
Code review: fixed small errors, defined some constants

### DIFF
--- a/include/TDApi/TDLibLogConfiguration.hpp
+++ b/include/TDApi/TDLibLogConfiguration.hpp
@@ -4,7 +4,15 @@
 class TDLibLogConfiguration : public Php::Base // namespace: TDApi
 {
     public:
-    TDLibLogConfiguration() = default;
+        static constexpr const int LVL_FATAL_ERROR = 0;
+        static constexpr const int LVL_ERROR = 1;
+        static constexpr const int LVL_WARNING = 2;
+        static constexpr const int LVL_INFO = 3;
+        static constexpr const int LVL_DEBUG = 4;
+        static constexpr const int LVL_VERBOSE_DEBUG = 5;
+        static constexpr const int LVL_ALL = 1024;
+
+        TDLibLogConfiguration() = default;
         virtual ~TDLibLogConfiguration() = default;
 
         static Php::Value setLogFilePath(Php::Parameters &params);

--- a/include/TDApi/TDLibParameters.cpp
+++ b/include/TDApi/TDLibParameters.cpp
@@ -4,24 +4,25 @@
 #include <phpcpp.h>
 
 #include "TDLibParameters.hpp"
+#include "../../tdlib.hpp"
 
 TDLibParameters::TDLibParameters()
 {
-    parameters["use_test_dc"] = false;
-    parameters["database_directory"] = "/var/tmp/tdlib";
-    parameters["files_directory"] = "/var/tmp/tdlib";
-    parameters["use_file_database"] = false;
-    parameters["use_chat_info_database"] = false;
-    parameters["use_message_database"] = false;
-    parameters["use_secret_chats"] = false;
-    parameters["api_id"] = 0;
-    parameters["api_hash"] = "";
-    parameters["system_language_code"] = "en";
-    parameters["device_model"] = "";
-    parameters["system_version"] = "";
-    parameters["application_version"] = "0.0.1";
-    parameters["enable_storage_optimizer"] = true;
-    parameters["ignore_file_names"] = false;
+    parameters[USE_TEST_DC] = false;
+    parameters[DATABASE_DIRECOTRY] = "/var/tmp/tdlib";
+    parameters[FILES_DIRECTORY] = "/var/tmp/tdlib";
+    parameters[USE_FILE_DATABASE] = false;
+    parameters[USE_CHAT_INFO_DATABASE] = false;
+    parameters[USE_MESSAGE_DATABASE] = false;
+    parameters[USE_SECRET_CHATS] = false;
+    parameters[API_ID] = 0;
+    parameters[API_HASH] = "";
+    parameters[SYSTEM_LANGUAGE_CODE] = "en";
+    parameters[DEVICE_MODEL] = "";
+    parameters[SYSTEM_VERSION] = "";
+    parameters[APPLICATION_VERSION] = TDLIB_PHP_VERSION;
+    parameters[ENABLE_STORAGE_OPTIMIZER] = true;
+    parameters[IGNORE_FILE_NAMES] = false;
 }
 
 Php::Value TDLibParameters::setParameter(Php::Parameters &params)
@@ -29,24 +30,30 @@ Php::Value TDLibParameters::setParameter(Php::Parameters &params)
     std::string parameter = params[0];
     Php::Value value = params[1];
 
-    if (value.isNumeric())
+    auto paramsIt = parameters.find(parameter);
+    if (paramsIt == parameters.end())
+    {
+        throw Php::Exception("Invalid parameter name");
+    }
+
+    if (value.isNumeric() && paramsIt->is_number())
     {
         int typedValue = value;
         parameters[parameter] = typedValue;
     }
-    else if (value.isString())
+    else if (value.isString() && paramsIt->is_string())
     {
         std::string typedValue = value;
         parameters[parameter] = typedValue;
     }
-    else if (value.isBool())
+    else if (value.isBool() && paramsIt->is_boolean())
     {
         bool typedValue = value;
         parameters[parameter] = typedValue;
     }
     else
     {
-        throw Php::Exception("TDLib parameter could be string, number or bool only");
+        throw Php::Exception("Invalid TDLib parameter type");
     }
     return this;
 }
@@ -81,7 +88,7 @@ Php::Value TDLibParameters::__debugInfo()
             phpValueParameters[iterator.key()] = nullptr;
         }
         else {
-            throw Php::Exception("Invalid TDLib parameter value");
+            assert(false);
         }
     }
 

--- a/include/TDApi/TDLibParameters.hpp
+++ b/include/TDApi/TDLibParameters.hpp
@@ -9,6 +9,22 @@ class TDLibParameters : public Php::Base // namespace: TDApi
         nlohmann::json parameters;
 
     public:
+        static constexpr const char* USE_TEST_DC = "use_test_dc";
+        static constexpr const char* DATABASE_DIRECOTRY = "database_directory";
+        static constexpr const char* FILES_DIRECTORY = "files_directory";
+        static constexpr const char* USE_FILE_DATABASE = "use_file_database";
+        static constexpr const char* USE_CHAT_INFO_DATABASE = "use_chat_info_database";
+        static constexpr const char* USE_MESSAGE_DATABASE = "use_message_database";
+        static constexpr const char* USE_SECRET_CHATS = "use_secret_chats";
+        static constexpr const char* API_ID = "api_id";
+        static constexpr const char* API_HASH = "api_hash";
+        static constexpr const char* SYSTEM_LANGUAGE_CODE = "system_language_code";
+        static constexpr const char* DEVICE_MODEL = "device_model";
+        static constexpr const char* SYSTEM_VERSION = "system_version";
+        static constexpr const char* APPLICATION_VERSION = "application_version";
+        static constexpr const char* ENABLE_STORAGE_OPTIMIZER = "enable_storage_optimizer";
+        static constexpr const char* IGNORE_FILE_NAMES = "ignore_file_names";
+
         TDLibParameters();
         virtual ~TDLibParameters() = default;
 

--- a/include/TDLib/BaseJsonClient.cpp
+++ b/include/TDLib/BaseJsonClient.cpp
@@ -20,45 +20,48 @@ void BaseJsonClient::create()
 
 void BaseJsonClient::destroy()
 {
-    if(_client == nullptr) Php::Exception("BaseJsonClient not created. Use create() method before destroy");
+    assert(_client != nullptr);
     td_json_client_destroy(_client);
     _client = nullptr;
 }
 
 Php::Value BaseJsonClient::execute(Php::Parameters &params)
 {
-    if(_client == nullptr) Php::Exception("BaseJsonClient not created. Use create() method before execute");
+    assert(_client != nullptr);
     const char *query = params[0];
     return execute(query);
 }
 
 std::string BaseJsonClient::execute(const char *query)
 {
+    assert(_client != nullptr);
     std::string result = td_json_client_execute(_client, query);
     return result;
 }
 
 void BaseJsonClient::send(Php::Parameters &params)
 {
-    if(_client == nullptr) Php::Exception("BaseJsonClient not created. Use create() method before send");
+    assert(_client != nullptr);
     const char *query = params[0];
     send(query);
 }
 
 void BaseJsonClient::send(const char *query)
 {
+    assert(_client != nullptr);
     td_json_client_send(_client, query);
 }
 
 Php::Value BaseJsonClient::receive(Php::Parameters &params)
 {
-    if(_client == nullptr) Php::Exception("BaseJsonClient not created. Use create() method before receive");
+    assert(_client != nullptr);
     double timeout = params[0];
     return receive(timeout);
 }
 
 std::string BaseJsonClient::receive(double timeout)
 {
+    assert(_client != nullptr);
     const char* result=td_json_client_receive(_client, timeout);
     if(result == nullptr) {
         return "";
@@ -78,46 +81,3 @@ void BaseJsonClient::__destruct()
 {
     if(_client != nullptr) destroy();
 }
-
-const char *BaseJsonClient::__toString()
-{
-    const char *str = "Object TDLib\\BaseJsonClient";
-    return str;
-}
-
-// Php::Value BaseJsonClient::__get(const Php::Value &name)
-// {
-//     Php::out << "__get " << name << std::endl << std::flush;
-//     return "__get";
-// }
-//
-// void BaseJsonClient::__set(const Php::Value &name, const Php::Value &value)
-// {
-//
-// }
-//
-// bool BaseJsonClient::__isset(const Php::Value &name)
-// {
-//     return true;
-// }
-//
-// void BaseJsonClient::__unset(const Php::Value &name)
-// {
-//     Php::error << "__unset " << name << std::endl << std::flush;
-// }
-//
-// Php::Value BaseJsonClient::__call(const char *name, Php::Parameters &params)
-// {
-//     Php::out << name << std::flush;
-//     return "__call";
-// }
-//
-// Php::Value BaseJsonClient::__callStatic(const char *name, Php::Parameters &params)
-// {
-//     return "__callStatic";
-// }
-//
-// Php::Value BaseJsonClient::__invoke(Php::Parameters &params)
-// {
-//     return "__invoke";
-// }

--- a/include/TDLib/JsonClient.cpp
+++ b/include/TDLib/JsonClient.cpp
@@ -84,7 +84,7 @@ std::string JsonClient::waitForResponse(json* extra,double timeout) {
         repeat=(time.count()<(int)(timeout*1000.));
     } while(repeat);
 
-    return "";
+    throw Php::Exception("Timeout waiting for response");
 }
 
 std::string JsonClient::query(const char *query, double timeout, json* extra) {
@@ -110,7 +110,7 @@ std::string JsonClient::addExtraAndSendQuery(std::string type, json* jsonQuery, 
 }
 
 double JsonClient::getTimeoutFromParams(Php::Parameters &params, int timeoutParameterIndex) {
-    if (params.size() <= timeoutParameterIndex)
+    if (params.size() <= timeoutParameterIndex || params[timeoutParameterIndex].isNull())
     {
         return defaultTimeout;
     }

--- a/include/TDLib/JsonClient.hpp
+++ b/include/TDLib/JsonClient.hpp
@@ -29,7 +29,7 @@ class JsonClient : public BaseJsonClient
         inline void __destruct() { BaseJsonClient::__destruct();};
         inline void create() { BaseJsonClient::create(); }
         inline void destroy() { BaseJsonClient::destroy(); }
-        inline Php::Value execute(Php::Parameters &params) { BaseJsonClient::execute(params); }
+        inline Php::Value execute(Php::Parameters &params) { return BaseJsonClient::execute(params); }
         inline void send(Php::Parameters &params) { BaseJsonClient::send(params); }
         Php::Value receive(Php::Parameters &params);
 

--- a/php_examples/client.php
+++ b/php_examples/client.php
@@ -13,26 +13,26 @@ $client->getAuthorizationState();
 
 $tdlibParams = new TDApi\TDLibParameters();
 $tdlibParams
-    ->setParameter('use_test_dc', true)
-    ->setParameter('database_directory', '/var/tmp/tdlib')
-    ->setParameter('files_directory', '/var/tmp/tdlib')
-    ->setParameter('use_file_database', false)
-    ->setParameter('use_chat_info_database', false)
-    ->setParameter('use_message_database', false)
-    ->setParameter('use_secret_chats', false)
-    ->setParameter('api_id', $api_id)
-    ->setParameter('api_hash', $api_hash)
-    ->setParameter('system_language_code', 'en')
-    ->setParameter('device_model', php_uname('s'))
-    ->setParameter('system_version', php_uname('v'))
-    ->setParameter('application_version', '0.0.7')
-    ->setParameter('enable_storage_optimizer', true)
-    ->setParameter('ignore_file_names', false);
+    ->setParameter(TDApi\TDLibParameters::USE_TEST_DC, true)
+    ->setParameter(TDApi\TDLibParameters::DATABASE_DIRECOTRY, '/var/tmp/tdlib')
+    ->setParameter(TDApi\TDLibParameters::FILES_DIRECTORY, '/var/tmp/tdlib')
+    ->setParameter(TDApi\TDLibParameters::USE_FILE_DATABASE, false)
+    ->setParameter(TDApi\TDLibParameters::USE_CHAT_INFO_DATABASE, false)
+    ->setParameter(TDApi\TDLibParameters::USE_MESSAGE_DATABASE, false)
+    ->setParameter(TDApi\TDLibParameters::USE_SECRET_CHATS, false)
+    ->setParameter(TDApi\TDLibParameters::API_ID, $api_id)
+    ->setParameter(TDApi\TDLibParameters::API_HASH, $api_hash)
+    ->setParameter(TDApi\TDLibParameters::SYSTEM_LANGUAGE_CODE, 'en')
+    ->setParameter(TDApi\TDLibParameters::DEVICE_MODEL, php_uname('s'))
+    ->setParameter(TDApi\TDLibParameters::SYSTEM_VERSION, php_uname('v'))
+    ->setParameter(TDApi\TDLibParameters::APPLICATION_VERSION, '0.0.7')
+    ->setParameter(TDApi\TDLibParameters::ENABLE_STORAGE_OPTIMIZER, true)
+    ->setParameter(TDApi\TDLibParameters::IGNORE_FILE_NAMES, false);
 $result = $client->setTdlibParameters($tdlibParams);
 $result = $client->setDatabaseEncryptionKey(); // checkDatabaseEncryptionKey(key) or DESTROY
 $result = $client->setAuthenticationPhoneNumber($phone_number);
 // $result = $client->query(json_encode(['@type' => 'checkAuthenticationCode', 'code' => 'xxx', 'first_name' => 'dummy', 'last_name' => 'dummy']), 10);
-$result = $client->getAuthorizationState(1.01234);
+$result = $client->getAuthorizationState();
 $result = $client->query(json_encode(['@type' => 'searchPublicChat', 'username' => 'telegram']), 10);
 var_dump($result);
 $client->destroy();

--- a/tdlib.cpp
+++ b/tdlib.cpp
@@ -5,6 +5,8 @@
 #include <td/telegram/tdjson_export.h>
 #include <td/telegram/td_json_client.h>
 
+#include "tdlib.hpp"
+
 #include "include/td_json_client_func.cpp"
 #include "include/TDLib/JsonClient.hpp"
 #include "include/TDApi/TDLibParameters.hpp"
@@ -14,7 +16,7 @@ extern "C" {
 
 PHPCPP_EXPORT void *get_module()
 {
-    static Php::Extension tdlib("tdlib", "0.0.8");
+    static Php::Extension tdlib("tdlib", TDLIB_PHP_VERSION);
 
 
     Php::Namespace TDLibNamespace("TDLib");
@@ -23,8 +25,6 @@ PHPCPP_EXPORT void *get_module()
     Php::Class<BaseJsonClient> base_json_client("BaseJsonClient");
     base_json_client.method<&BaseJsonClient::__construct> ("__construct");
     base_json_client.method<&BaseJsonClient::__destruct> ("__destruct");
-    base_json_client.method<&BaseJsonClient::create> ("create");
-    base_json_client.method<&BaseJsonClient::destroy> ("destroy");
     base_json_client.method<&BaseJsonClient::execute> ("execute", {
         Php::ByVal("query", Php::Type::String)
     });
@@ -69,7 +69,6 @@ PHPCPP_EXPORT void *get_module()
         Php::ByVal("timeout", Php::Type::Float, false)
     });
     json_client.method<&JsonClient::getAuthorizationState> ("getAuthorizationState", {
-        Php::ByVal("extra", Php::Type::Float, false),
         Php::ByVal("timeout", Php::Type::Float, false)
     });
     json_client.method<&JsonClient::setAuthenticationPhoneNumber> ("setAuthenticationPhoneNumber", {
@@ -103,6 +102,22 @@ PHPCPP_EXPORT void *get_module()
     });
     td_api_tdlibParameters.method<&TDLibParameters::__debugInfo> ("__debugInfo");
 
+    td_api_tdlibParameters.property("USE_TEST_DC", TDLibParameters::USE_TEST_DC, Php::Const);
+    td_api_tdlibParameters.property("DATABASE_DIRECOTRY", TDLibParameters::DATABASE_DIRECOTRY, Php::Const);
+    td_api_tdlibParameters.property("FILES_DIRECTORY", TDLibParameters::FILES_DIRECTORY, Php::Const);
+    td_api_tdlibParameters.property("USE_FILE_DATABASE", TDLibParameters::USE_FILE_DATABASE, Php::Const);
+    td_api_tdlibParameters.property("USE_CHAT_INFO_DATABASE", TDLibParameters::USE_CHAT_INFO_DATABASE, Php::Const);
+    td_api_tdlibParameters.property("USE_MESSAGE_DATABASE", TDLibParameters::USE_MESSAGE_DATABASE, Php::Const);
+    td_api_tdlibParameters.property("USE_SECRET_CHATS", TDLibParameters::USE_SECRET_CHATS, Php::Const);
+    td_api_tdlibParameters.property("API_ID", TDLibParameters::API_ID, Php::Const);
+    td_api_tdlibParameters.property("API_HASH", TDLibParameters::API_HASH, Php::Const);
+    td_api_tdlibParameters.property("SYSTEM_LANGUAGE_CODE", TDLibParameters::SYSTEM_LANGUAGE_CODE, Php::Const);
+    td_api_tdlibParameters.property("DEVICE_MODEL", TDLibParameters::DEVICE_MODEL, Php::Const);
+    td_api_tdlibParameters.property("SYSTEM_VERSION", TDLibParameters::SYSTEM_VERSION, Php::Const);
+    td_api_tdlibParameters.property("APPLICATION_VERSION", TDLibParameters::APPLICATION_VERSION, Php::Const);
+    td_api_tdlibParameters.property("ENABLE_STORAGE_OPTIMIZER", TDLibParameters::ENABLE_STORAGE_OPTIMIZER, Php::Const);
+    td_api_tdlibParameters.property("IGNORE_FILE_NAMES", TDLibParameters::IGNORE_FILE_NAMES, Php::Const);
+
     TDApiNamespace.add(std::move(td_api_tdlibParameters));
 
 
@@ -118,13 +133,13 @@ PHPCPP_EXPORT void *get_module()
         Php::ByVal("logVerbosityLevel", Php::Type::Numeric)
     });
 
-    td_api_logConfiguration.property("LVL_FATAL_ERROR", 0, Php::Const);
-    td_api_logConfiguration.property("LVL_ERROR", 1, Php::Const);
-    td_api_logConfiguration.property("LVL_WARNING", 2, Php::Const);
-    td_api_logConfiguration.property("LVL_INFO", 3, Php::Const);
-    td_api_logConfiguration.property("LVL_DEBUG", 4, Php::Const);
-    td_api_logConfiguration.property("LVL_VERBOSE_DEBUG", 5, Php::Const);
-    td_api_logConfiguration.property("LVL_ALL", 1024, Php::Const);
+    td_api_logConfiguration.property("LVL_FATAL_ERROR", TDLibLogConfiguration::LVL_FATAL_ERROR, Php::Const);
+    td_api_logConfiguration.property("LVL_ERROR", TDLibLogConfiguration::LVL_ERROR, Php::Const);
+    td_api_logConfiguration.property("LVL_WARNING", TDLibLogConfiguration::LVL_WARNING, Php::Const);
+    td_api_logConfiguration.property("LVL_INFO", TDLibLogConfiguration::LVL_INFO, Php::Const);
+    td_api_logConfiguration.property("LVL_DEBUG", TDLibLogConfiguration::LVL_DEBUG, Php::Const);
+    td_api_logConfiguration.property("LVL_VERBOSE_DEBUG", TDLibLogConfiguration::LVL_VERBOSE_DEBUG, Php::Const);
+    td_api_logConfiguration.property("LVL_ALL", TDLibLogConfiguration::LVL_ALL, Php::Const);
 
     TDApiNamespace.add(std::move(td_api_logConfiguration));
 

--- a/tdlib.hpp
+++ b/tdlib.hpp
@@ -1,0 +1,1 @@
+#define TDLIB_PHP_VERSION "0.0.8"


### PR DESCRIPTION
@yaroslavche I begun to write stubs, but found some errors in the code. Here I fix them.

The main points are:
* missing return statement in JsonClient::execute
* timeout parameter in JsonClient methods could be passed with NULL value
* no need for BaseJsonClient::create and BaseJsonClient::destroy to be public
* changed lots of exceptions in BaseJsonClient to assertions
* parameters names in TDLibParameters have to be verified

Please, look through my changes before merging the pull request.